### PR TITLE
polished makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,3 @@ dev-deps:
 
 clean:
 	go clean
-
-dist-clean:
-	rm -rf pkg src bin
-


### PR DESCRIPTION
- dist-clean is not needed anymore as we build with `go install`
